### PR TITLE
Change some `try( ..., silent = TRUE)` to `silent = FALSE`

### DIFF
--- a/R/Rcgminb.R
+++ b/R/Rcgminb.R
@@ -234,7 +234,7 @@ Rcgminb <- function(par, fn, gr, lower, upper, bdmsk = NULL, control = list(), .
         cat("Try function at initial point:")
         print(bvec)
     }
-    f <- try(fn(bvec, ...), silent = TRUE)  # Compute the function at initial point.
+    f <- try(fn(bvec, ...), silent = FALSE)  # Compute the function at initial point.
     if (trace > 0) {
         cat("Initial function value=", f, "\n")
     }

--- a/R/Rcgminu.R
+++ b/R/Rcgminu.R
@@ -121,7 +121,7 @@ Rcgminu <- function(par, fn, gr, control = list(), ...) {
         cat("Try function at initial point:")
         print(bvec)
     }
-    f <- try(fn(bvec, ...), silent = TRUE)  # Compute the function at initial point.
+    f <- try(fn(bvec, ...), silent = FALSE)  # Compute the function at initial point.
     if (trace > 0) {
         cat("Initial function value=", f, "\n")
     }

--- a/R/Rvmminb.R
+++ b/R/Rvmminb.R
@@ -152,7 +152,7 @@ Rvmminb <- function(par, fn, gr = NULL, lower = NULL,
   } # end else
   ############# end test gr ####################
   # Assume bounds already checked 150108
-  f<-try(fn(bvec, ...), silent=TRUE) # Compute the function.
+  f<-try(fn(bvec, ...), silent=FALSE) # Compute the function.
   if (inherits(f,"try-error") | is.na(f) | is.null(f) | is.infinite(f)) {
      msg <- "Initial point gives inadmissible function value"
      conv <- 20
@@ -350,7 +350,7 @@ Rvmminb <- function(par, fn, gr = NULL, lower = NULL,
           }  # end test on free params
         }  # end reactivate constraints loop
         ###   }  # if bounds
-        test <- try(g <- mygr(bvec, ...), silent = TRUE) 
+        test <- try(g <- mygr(bvec, ...), silent = FALSE)
         if (inherits(test, "try-error")) stop("Bad gradient!!")
         if (any(is.nan(g))) stop("NaN in gradient")
         ig <- ig + 1

--- a/R/Rvmminu.R
+++ b/R/Rvmminu.R
@@ -150,7 +150,7 @@ Rvmminu <- function(par, fn, gr=NULL, control = list(), ...) {
   } # end else
   ############# end setup gr ####################
   #
-  f<-try(fn(bvec, ...), silent=TRUE) # Compute the function.
+  f<-try(fn(bvec, ...), silent=FALSE) # Compute the function.
   if (inherits(f, "try-error") | is.na(f) | is.null(f) | is.infinite(f)) {
      msg <- "Initial point gives inadmissible function value"
      conv <- 20
@@ -347,7 +347,7 @@ Rvmminu <- function(par, fn, gr=NULL, control = list(), ...) {
 #
 #
 #
-        test <- try(g <- mygr(bvec, ...), silent = TRUE)  
+        test <- try(g <- mygr(bvec, ...), silent = FALSE)
         if (inherits(test, "try-error") ) stop("Bad gradient!!")
         if (any(is.nan(g))) stop("NaN in gradient")
         ig <- ig + 1

--- a/R/gHgen.R
+++ b/R/gHgen.R
@@ -59,7 +59,7 @@ gHgen <- function(par, fn, gr = NULL, hess = NULL, control = list(ktrace=0),
     if (is.null(hess)) {
         if (is.null(gr)) {
             if (ctrl$ktrace>0) cat("is.null(gr) is TRUE use numDeriv hessian()\n") 
-            Hn <- try(hessian(fn, par, ...), silent = TRUE)  # change 20100711
+            Hn <- try(hessian(fn, par, ...), silent = FALSE)  # change 20100711
             if (inherits(Hn, "try-error")) {
                 if (ctrl$stoponerror) 
                   stop("Unable to compute Hessian using numDeriv::hessian")
@@ -69,7 +69,7 @@ gHgen <- function(par, fn, gr = NULL, hess = NULL, control = list(ktrace=0),
         }
         else {
             if (ctrl$ktrace>0) cat("is.null(gr) is FALSE use numDeriv jacobian()\n") 
-            Hn <- try(jacobian(gr, par, ...), silent = TRUE)  # change 20100711
+            Hn <- try(jacobian(gr, par, ...), silent = FALSE)  # change 20100711
             if (inherits(Hn, "try-error")) {
                 if (ctrl$stoponerror) 
                   stop("Unable to compute Hessian using numderiv::jacobian")
@@ -102,7 +102,7 @@ gHgen <- function(par, fn, gr = NULL, hess = NULL, control = list(ktrace=0),
     }
     else {
         if (ctrl$ktrace>0) cat("is.null(hess) is FALSE -- trying hess()\n") 
-        Hn <- try(hess(par, ...), silent = TRUE)  # change 20110222
+        Hn <- try(hess(par, ...), silent = FALSE)  # change 20110222
         if (inherits(Hn, "try-error")) {
             if (ctrl$stoponerror) 
                 stop("Hessian evaluation with function hess() failed")

--- a/R/ncg.R
+++ b/R/ncg.R
@@ -47,7 +47,7 @@ ncg <- function(par, fn, gr, bds, control = list()) {
             " bounds = ", bounds, "\n")
     # Initial function value -- may NOT be at initial point specified by user.
     if (trace > 2) {cat("Try function at initial point:");  print(bvec)  }
-    f <- try(fn(bvec), silent = TRUE)  # Compute the function at initial point.
+    f <- try(fn(bvec), silent = FALSE)  # Compute the function at initial point.
     if (trace > 0) { cat("Initial function value=", f, "\n") }
     if (inherits(f,"try-error")) {
         msg <- "Initial point is infeasible."

--- a/R/nvm.R
+++ b/R/nvm.R
@@ -128,7 +128,7 @@ nvm <- function(par, fn, gr, bds, control = list()) {
   }
   else {  mygr<-gr } # end else
   ############# end test gr ####################
-  f<-try(fn(bvec), silent=TRUE) # Compute the function. NO dotargs!!!
+  f<-try(fn(bvec), silent=FALSE) # Compute the function. NO dotargs!!!
   if (inherits(f,"try-error") | is.na(f) | is.null(f) | is.infinite(f)) {
      msg <- "Initial point gives inadmissible function value"
      conv <- 20
@@ -308,7 +308,7 @@ nvm <- function(par, fn, gr, bds, control = list()) {
           }  # end test on free params
         }  # end reactivate constraints loop
       }  # if bounds
-      test <- try(g <- mygr(bvec), silent = TRUE) 
+      test <- try(g <- mygr(bvec), silent = FALSE)
       if (inherits(test, "try-error")) stop("Bad gradient!!")
       if (any(is.nan(g))) stop("NaN in gradient")
       ig <- ig + 1

--- a/R/optimx.check.R
+++ b/R/optimx.check.R
@@ -50,7 +50,7 @@ optimx.check <- function(par, ufn, ugr, uhess, lower=-Inf, upper=Inf,
 	  } 
   	} # end have.bounds
         # Check if function can be computed
-        firsttry<-try(finit<-ufn(par), silent=TRUE ) # 20100711
+        firsttry<-try(finit<-ufn(par), silent=FALSE ) # 20100711
         # Note: This incurs one EXTRA function evaluation because optimx is a wrapper for other methods
         if (inherits(firsttry, "try-error")) {
     	   infeasible <- TRUE


### PR DESCRIPTION
…so coding errors will be shown.

- I tried to target cases where a try error would abort the run, so we shouldn't get huge repetitive lists of expected errors.

- Motivated by https://stackoverflow.com/q/77311460, where a coding error left the user confused because `silent = TRUE` hid the error message.